### PR TITLE
arch: dts: support more Yukon variants

### DIFF
--- a/arch/arm/boot/dts/msm8226-v2-yukon_eagle-720p-mtp.dts
+++ b/arch/arm/boot/dts/msm8226-v2-yukon_eagle-720p-mtp.dts
@@ -1,0 +1,23 @@
+/* Copyright (c) 2013, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+
+/dts-v1/;
+/include/ "msm8226-v2.dtsi"
+/include/ "msm8226-yukon_eagle-720p-mtp.dtsi"
+/include/ "msm8226-yukon_eagle-camera-sensor-mtp.dtsi"
+
+/ {
+	model = "Qualcomm MSM 8226v2 MTP";
+	compatible = "qcom,msm8226-mtp", "qcom,msm8226", "qcom,mtp", "somc,eagle";
+	qcom,board-id = <8 0>;
+};

--- a/arch/arm/boot/dts/msm8226-v2-yukon_flamingo-8226ds_dp.dts
+++ b/arch/arm/boot/dts/msm8226-v2-yukon_flamingo-8226ds_dp.dts
@@ -1,0 +1,23 @@
+/* Copyright (c) 2013, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+
+/dts-v1/;
+/include/ "msm8226-v2.dtsi"
+/include/ "msm8226-yukon_flamingo-mtp.dtsi"
+/include/ "msm8226-yukon_flamingo-camera-sensor.dtsi"
+
+/ {
+	model = "Qualcomm MSM 8226v2 MTP (Arima 8226DS DP)";
+	compatible = "qcom,msm8226-mtp", "qcom,msm8226", "qcom,mtp", "somc,flamingo";
+	qcom,board-id = <8 0>;
+};

--- a/arch/arm/boot/dts/msm8226-v2-yukon_flamingo-8226ss_dp.dts
+++ b/arch/arm/boot/dts/msm8226-v2-yukon_flamingo-8226ss_dp.dts
@@ -1,0 +1,23 @@
+/* Copyright (c) 2013, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+
+/dts-v1/;
+/include/ "msm8226-v2.dtsi"
+/include/ "msm8226-yukon_flamingo-mtp.dtsi"
+/include/ "msm8226-yukon_flamingo-camera-sensor.dtsi"
+
+/ {
+	model = "Qualcomm MSM 8226v2 MTP (Arima 8226SS DP)";
+	compatible = "qcom,msm8226-mtp", "qcom,msm8226", "qcom,mtp", "somc,flamingo";
+	qcom,board-id = <8 0>;
+};

--- a/arch/arm/boot/dts/msm8226-v2-yukon_seagull-720p-mtp.dts
+++ b/arch/arm/boot/dts/msm8226-v2-yukon_seagull-720p-mtp.dts
@@ -1,0 +1,24 @@
+/* Copyright (c) 2013, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+
+/dts-v1/;
+/include/ "msm8226-v2.dtsi"
+/include/ "msm8226-yukon_seagull-720p-mtp.dtsi"
+/include/ "msm8226-yukon_seagull-camera-sensor.dtsi"
+
+
+/ {
+	model = "Qualcomm MSM 8226v2 MTP";
+	compatible = "qcom,msm8226-mtp", "qcom,msm8226", "qcom,mtp", "somc,seagull";
+	qcom,board-id = <8 0>;
+};

--- a/arch/arm/boot/dts/msm8226-yukon_eagle-mtp.dts
+++ b/arch/arm/boot/dts/msm8226-yukon_eagle-mtp.dts
@@ -1,0 +1,30 @@
+/* Copyright (c) 2013, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+
+/dts-v1/;
+/include/ "msm8226-v1.dtsi"
+/include/ "msm8226-yukon_eagle-720p-mtp.dtsi"
+/include/ "msm8226-yukon_eagle-camera-sensor-mtp.dtsi"
+
+/ {
+	model = "Qualcomm MSM 8226 MTP";
+	compatible = "qcom,msm8226-mtp", "qcom,msm8226", "qcom,mtp", "somc,eagle";
+	qcom,board-id = <8 0>;
+};
+
+&cci {
+	/* Rotate rear camera to 180 degrees */
+	qcom,camera@6f {
+	qcom,mount-angle = <180>;
+	};
+};

--- a/arch/arm/boot/dts/msm8926-v2-yukon_eagle-720p-mtp.dts
+++ b/arch/arm/boot/dts/msm8926-v2-yukon_eagle-720p-mtp.dts
@@ -1,0 +1,32 @@
+/* Copyright (c) 2013, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+
+/dts-v1/;
+/include/ "msm8926-v2.dtsi"
+/include/ "msm8226-yukon_eagle-720p-mtp.dtsi"
+/include/ "msm8226-yukon_eagle-camera-sensor-mtp.dtsi"
+
+/ {
+	model = "Qualcomm MSM 8926 MTP";
+	compatible = "qcom,msm8926-mtp", "qcom,msm8926", "qcom,mtp", "somc,eagle";
+	qcom,board-id = <8 0>;
+};
+
+&smsc_hub {
+	status = "ok";
+	smsc,model-id = <3502>;
+	smsc,reset-gpio = <&msmgpio 114 0x00>;
+	smsc,int-gpio = <&msmgpio 9 0x00>;
+	smsc,xo-clk-gpio = <&msmgpio 8 0x00>;
+	hub-int-supply = <&pm8226_l6>;
+};

--- a/arch/arm/mach-msm/Makefile.boot
+++ b/arch/arm/mach-msm/Makefile.boot
@@ -101,11 +101,17 @@ endif
 # MSM8226
    zreladdr-$(CONFIG_ARCH_MSM8226)	:= 0x00008000
 	dtb-$(CONFIG_MACH_SONY_EAGLE)	+= msm8926-yukon_eagle-720p-mtp.dtb
+	dtb-$(CONFIG_MACH_SONY_EAGLE)	+= msm8926-v2-yukon_eagle-720p-mtp.dtb
+	dtb-$(CONFIG_MACH_SONY_EAGLE)	+= msm8226-yukon_eagle-mtp.dtb
+	dtb-$(CONFIG_MACH_SONY_EAGLE)	+= msm8226-v2-yukon_eagle-720p-mtp.dtb
 	dtb-$(CONFIG_MACH_SONY_FLAMINGO)+= msm8926-yukon_flamingo-8926ss_ap.dtb
+	dtb-$(CONFIG_MACH_SONY_FLAMINGO)+= msm8226-v2-yukon_flamingo-8226ss_dp.dtb
+	dtb-$(CONFIG_MACH_SONY_FLAMINGO)+= msm8226-v2-yukon_flamingo-8226ds_dp.dtb
         dtb-$(CONFIG_MACH_SONY_TIANCHI) += msm8226-v1-yukon_tianchi_dsds.dtb
         dtb-$(CONFIG_MACH_SONY_TIANCHI) += msm8226-v2-yukon_tianchi_dsds.dtb
 	dtb-$(CONFIG_MACH_SONY_TIANCHI) += msm8926-yukon_tianchi.dtb
 	dtb-$(CONFIG_MACH_SONY_SEAGULL) += msm8926-yukon_seagull-720p-mtp.dtb
+	dtb-$(CONFIG_MACH_SONY_SEAGULL) += msm8226-v2-yukon_seagull-720p-mtp.dtb
 
 # FSM9XXX
    zreladdr-$(CONFIG_ARCH_FSM9XXX)	:= 0x10008000


### PR DESCRIPTION
With this we bring support for 3G devices on seagull, flamingo and eagle and for msm8926 v2 on eagle.